### PR TITLE
added stackCode

### DIFF
--- a/Stacks/stackScratch.cpp
+++ b/Stacks/stackScratch.cpp
@@ -1,0 +1,46 @@
+#include<bits/stdc++.h>
+using namespace std;
+template<typename T>
+class stk
+{
+	public:
+	stk* head;
+	stk* next;
+	T val;
+	stk()
+	{
+		head = NULL;
+		next = NULL;
+	}
+	T top()
+	{
+		return head->val;
+	}
+	bool empty()
+	{
+		return head == NULL;
+	}
+	void push(T x)
+	{
+		stk* node = new stk();
+		node->val = x;
+		node->next = head;
+		head = node;
+	}
+	void pop()
+	{
+		head = head->next;
+	}
+};
+//Driver code
+int main()
+{
+	stk<int> st;
+	st.push(0);
+	st.push(1);
+	while(!st.empty())
+	{
+		cout<<st.top()<<endl;
+		st.pop();
+	}
+}


### PR DESCRIPTION
Often in coding rounds, STL is not allowed to be used. This is a simple implementation of stack Template in CPP using the linked list that can be easily used in coding rounds for quick implementation of codes requiring the use of stack. 